### PR TITLE
Allow to define uproject_path relative to the configuration file

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,9 +6,10 @@
       "request": "launch",
       "module": "generator",
       "args": [
-        "D:/Projects/Summercamp_pyscripts/Scripts/Build/Jenkins/Config/jenkinsfile_pull_request.yaml",
+        "E:/Dev/Projects/Summercamp_pyscripts/Scripts/Build/Jenkins/Config/jenkinsfile_pull_request.yaml",
         "--output",
-        "D:/Projects/Summercamp_pyscripts/Scripts/Build/Jenkins/Jenkinsfile",
+        "E:/Dev/Projects/Summercamp_pyscripts/Scripts/Build/Jenkins/Jenkinsfile",
+        "--lint"
       ]
     }
   ]

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Each feature has an associated Mako template in `generator/templates/` that defi
 ```mako
 <!-- git.mako -->
 <%def name="additional_functions()">
-def gitCheckout() {
+def checkout() {
     % if feature_config.use_simple_checkout:
         checkout scm
     % else:

--- a/generator/core/base_feature.py
+++ b/generator/core/base_feature.py
@@ -42,13 +42,13 @@ class BaseFeature(ABC):
         """Return the Pydantic model for validating this feature's config."""
         pass
 
-    def get_feature_config(self, full_config: PipelineConfig) -> Dict[str, Any]:
+    def get_feature_config(self, full_config: PipelineConfig, context: Any) -> Dict[str, Any]:
         """Extract and validate this feature's config from the full config."""
         feature_config = full_config.features.get(self.feature_name, {})
         
         config_model = self.get_config_model()
         try:
-            validated = config_model(**feature_config)
+            validated = config_model.model_validate(feature_config, context=context)
             return validated
         except ValidationError as e:
             raise ValueError(f"Invalid config for feature '{self.feature_name}': {e}")

--- a/generator/core/jenkins_file_generator.py
+++ b/generator/core/jenkins_file_generator.py
@@ -39,7 +39,8 @@ class JenkinsfileGenerator:
 
         for feature in ordered_features:
             try:
-                feature_config = feature.get_feature_config(config)
+                validation_context = {'config_file_path': config_path}            
+                feature_config = feature.get_feature_config(config, validation_context)
                 context = TemplateContext(
                     full_config=config,
                     feature_config=feature_config,
@@ -60,7 +61,8 @@ class JenkinsfileGenerator:
         try:
             with open(config_path, 'r') as f:
                 yaml_contents = yaml.safe_load(f)
-                return PipelineConfig(**yaml_contents)
+                validation_context = {'config_file_path': config_path}
+                return PipelineConfig.model_validate(yaml_contents, context=validation_context)
         except Exception as e:
             raise ValueError(f"Failed to load config file '{config_path}': {e}")
 

--- a/generator/features/unreal.py
+++ b/generator/features/unreal.py
@@ -33,50 +33,41 @@ class UnrealProjectConfig(BaseModel):
     uproject_path: Path = Field(description="The path to the .uproject file of the Unreal project.")
     pyscripts_folder: Path = Field(default_factory=lambda: None, description="Path to the PyScripts folder if it's not at the root of the uproject") 
     # Done like this to make it optional in the config file but will try to be set to a relative path from the uproject_path
-
-    @field_validator('uproject_path')
-    @classmethod
-    def validate_uproject_path(cls, uproject_path : Path, info: ValidationInfo) -> Path:
-        """Validate the uproject file exists."""
-        if not uproject_path.is_absolute():
+    
+    @model_validator(mode='after')
+    def validate_model(self, info: ValidationInfo) -> 'UnrealProjectConfig':
+        """Validation of the project config model and try to resolve paths to the uproject file and pyscripts folder."""
+        if not self.uproject_path.is_absolute():
             config_file_path = info.context.get('config_file_path') if info.context else None
 
             if config_file_path:
                 # Resolve relative to config file directory
                 config_dir = Path(config_file_path).parent
-                uproject_path = (config_dir / uproject_path).resolve()
-                logger.debug(f"Resolved uproject_path relative to config file: {uproject_path}")
+                self.uproject_path = (config_dir / self.uproject_path).resolve()
+                logger.debug(f"Resolved uproject_path relative to config file: {self.uproject_path}")
             else:
-                # Fallback to current working directory
                 return None
-                # uproject_path = None uproject_path.resolve()
-                # logger.warning(f"No config file path in context, resolving relative to CWD: {uproject_path}")
 
-        if not uproject_path.is_file():
+        if not self.uproject_path.is_file():
             raise ValueError('uproject_path does not point to a valid file')
         
-        logger.info(f"Resolved uproject_path: {uproject_path}")
+        logger.info(f"Resolved uproject_path: {self.uproject_path}")
 
-        return uproject_path
-    
-    @model_validator(mode='after')
-    def validate_model(self) -> 'UnrealProjectConfig':
-        """Validate the location of the UEPyscripts package."""
         if self.pyscripts_folder is None:
             logger.debug(f"pyscripts_folder is not set. Default to PyScripts")
             self.pyscripts_folder = Path("PyScripts")
 
-        # if not self.pyscripts_folder.is_absolute():
-        #     uproject_path = self.uproject_path
-        #     if uproject_path is None:
-        #         raise ValueError("uproject_path must be validated before pyscripts_folder")
+        if not self.pyscripts_folder.is_absolute():
+            uproject_path = self.uproject_path
+            if uproject_path is None:
+                raise ValueError("uproject_path must be validated before pyscripts_folder")
 
-        #     logger.debug(f"pyscripts_path is a relative path, resolving against the uproject located at {uproject_path}")
+            logger.debug(f"pyscripts_path is a relative path, resolving against the uproject located at {uproject_path}")
 
-        #     self.pyscripts_folder = uproject_path.parent / self.pyscripts_folder
+            self.pyscripts_folder = uproject_path.parent / self.pyscripts_folder
 
-        # if not self.pyscripts_folder.is_dir():
-        #     raise ValueError(f"Pyscripts folder not found at {self.pyscripts_folder}.")
+        if not self.pyscripts_folder.is_dir():
+            raise ValueError(f"Pyscripts folder not found at {self.pyscripts_folder}.")
 
         logger.info(f"Resolved pyscripts_folder: {self.pyscripts_folder}")
         return self

--- a/generator/features/unreal.py
+++ b/generator/features/unreal.py
@@ -3,7 +3,7 @@ import json
 import os
 import sys
 from typing import Any, Dict, List, Optional
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, Field, ValidationInfo, field_validator, model_validator
 from pathlib import Path
 from mako.template import Template
 
@@ -36,13 +36,21 @@ class UnrealProjectConfig(BaseModel):
 
     @field_validator('uproject_path')
     @classmethod
-    def validate_uproject_path(cls, uproject_path : Path) -> Path:
+    def validate_uproject_path(cls, uproject_path : Path, info: ValidationInfo) -> Path:
         """Validate the uproject file exists."""
         if not uproject_path.is_absolute():
-            logger.debug(f"uproject_path is a relative path, resolving against the current file's directory")
+            config_file_path = info.context.get('config_file_path') if info.context else None
 
-            this_file_folder_path = Path(__file__).parent
-            uproject_path = (this_file_folder_path / "../../" / uproject_path).absolute()
+            if config_file_path:
+                # Resolve relative to config file directory
+                config_dir = Path(config_file_path).parent
+                uproject_path = (config_dir / uproject_path).resolve()
+                logger.debug(f"Resolved uproject_path relative to config file: {uproject_path}")
+            else:
+                # Fallback to current working directory
+                return None
+                # uproject_path = None uproject_path.resolve()
+                # logger.warning(f"No config file path in context, resolving relative to CWD: {uproject_path}")
 
         if not uproject_path.is_file():
             raise ValueError('uproject_path does not point to a valid file')
@@ -58,17 +66,17 @@ class UnrealProjectConfig(BaseModel):
             logger.debug(f"pyscripts_folder is not set. Default to PyScripts")
             self.pyscripts_folder = Path("PyScripts")
 
-        if not self.pyscripts_folder.is_absolute():
-            uproject_path = self.uproject_path
-            if uproject_path is None:
-                raise ValueError("uproject_path must be validated before pyscripts_folder")
+        # if not self.pyscripts_folder.is_absolute():
+        #     uproject_path = self.uproject_path
+        #     if uproject_path is None:
+        #         raise ValueError("uproject_path must be validated before pyscripts_folder")
 
-            logger.debug(f"pyscripts_path is a relative path, resolving against the uproject located at {uproject_path}")
+        #     logger.debug(f"pyscripts_path is a relative path, resolving against the uproject located at {uproject_path}")
 
-            self.pyscripts_folder = uproject_path.parent / self.pyscripts_folder
+        #     self.pyscripts_folder = uproject_path.parent / self.pyscripts_folder
 
-        if not self.pyscripts_folder.is_dir():
-            raise ValueError(f"Pyscripts folder not found at {self.pyscripts_folder}.")
+        # if not self.pyscripts_folder.is_dir():
+        #     raise ValueError(f"Pyscripts folder not found at {self.pyscripts_folder}.")
 
         logger.info(f"Resolved pyscripts_folder: {self.pyscripts_folder}")
         return self

--- a/generator/templates/git.mako
+++ b/generator/templates/git.mako
@@ -1,7 +1,7 @@
 <%namespace name="groovy" module="generator.utils.groovy"/>
 
 <%def name="additional_functions()">
-def gitCheckout() {
+def checkout() {
 % if feature_config.use_simple_checkout:
     checkout scm
 % else:

--- a/generator/templates/unreal.mako
+++ b/generator/templates/unreal.mako
@@ -58,7 +58,7 @@ def runBuildGraph( groupName, taskNames, platform, properties ) {
         
         ${utils.get_workspace()}
         {
-            gitCheckout()
+            checkout()
 
             taskNames.each { String taskName ->
                 stage( taskName ) {
@@ -113,7 +113,7 @@ def cleanup() {
 
         ${utils.get_workspace()} 
         {
-            gitCheckout()
+            checkout()
 
             stage ( "Cleanup" ) {
                 <%text>

--- a/generator/utils/validation/config_validator.py
+++ b/generator/utils/validation/config_validator.py
@@ -147,7 +147,8 @@ class ConfigValidator(BaseValidator):
         try:
             with open(self.config_path, 'r') as f:
                 yaml_contents = yaml.safe_load(f)
-                validated_config = PipelineConfig(**yaml_contents)
+                validation_context = {'config_file_path': self.config_path}
+                validated_config = PipelineConfig(**yaml_contents, context=validation_context)
                 self.validated_config = validated_config                
             
         except ValidationError as e:
@@ -201,7 +202,8 @@ class ConfigValidator(BaseValidator):
             try:
                 feature_class = available_features[feature_name]
                 feature_instance = feature_class()
-                feature_instance.get_feature_config(self.validated_config)
+                validation_context = {'config_file_path': self.config_path}
+                feature_instance.get_feature_config(self.validated_config, validation_context)
                 
             except ValidationError as e:
                 for error in e.errors():


### PR DESCRIPTION
- **Resolve path to the uproject relatively to the config file being used**
- **Validate both uproject_path and pyscripts in a model validator to allow to resolve both relatively to the path of the config file used by the generator**
- **Renamed gitCheckout() to checkout()**
